### PR TITLE
Remove unecessary owner type criteria

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -160,13 +160,6 @@ final class Query
         $criteria = [
             $inverseField   => (array) $identifiers,
         ];
-        if (true === $owner->isChildEntity()) {
-            // The owner is owned by a polymorphic model. Must include the type with the inverse field criteria.
-            $criteria[$inverseField] = [
-                Persister::IDENTIFIER_KEY   => $criteria[$inverseField],
-                Persister::POLYMORPHIC_KEY  => $owner->type,
-            ];
-        }
         if (true === $related->isChildEntity()) {
             // The relationship is owned by a polymorphic model. Must include the type in the root criteria.
             $criteria[Persister::POLYMORPHIC_KEY] = $related->type;


### PR DESCRIPTION
Mistakenly included owner polymorphic information within the inverse relationhip criteria generation. This was causing inverse poly rels to break.
