### PR TITLE
Schema management

### DIFF
--- a/src/Persister.php
+++ b/src/Persister.php
@@ -108,6 +108,9 @@ final class Persister implements PersisterInterface
      */
     public function createSchemata(EntityMetadata $metadata)
     {
+        if (!$metadata->persistence instanceof StorageMetadata) {
+            throw PersisterException::badRequest('Wrong StorageMetadata type');
+        }
         $collection = $this->getQuery()->getModelCollection($metadata);
         $schemata = $metadata->persistence->schemata ?: [];
         return $this->schemaManager->createSchemata($collection, $schemata);
@@ -118,6 +121,9 @@ final class Persister implements PersisterInterface
      */
     public function syncSchemata(EntityMetadata $metadata)
     {
+        if (!$metadata->persistence instanceof StorageMetadata) {
+            throw PersisterException::badRequest('Wrong StorageMetadata type');
+        }
         $collection = $this->getQuery()->getModelCollection($metadata);
         $schemata = $metadata->persistence->schemata ?: [];
         return $this->schemaManager->syncSchemata($collection);

--- a/src/Persister.php
+++ b/src/Persister.php
@@ -42,6 +42,11 @@ final class Persister implements PersisterInterface
     private $hydrator;
 
     /**
+     * @var SchemaManager
+     */
+    private $schemaManager;
+
+    /**
      * @var StorageMetadataFactory
      */
     private $smf;
@@ -60,11 +65,12 @@ final class Persister implements PersisterInterface
      * @param   StorageMetadataFactory  $smf
      * @param   Hydrator                $hydrator
      */
-    public function __construct(Query $query, StorageMetadataFactory $smf, Hydrator $hydrator)
+    public function __construct(Query $query, StorageMetadataFactory $smf, Hydrator $hydrator, SchemaManager $schemaManager)
     {
         $this->smf = $smf;
         $this->query = $query;
         $this->hydrator = $hydrator;
+        $this->schemaManager = $schemaManager;
     }
 
     /**
@@ -95,6 +101,26 @@ final class Persister implements PersisterInterface
         $insert = $this->createInsertObj($model);
         $this->getQuery()->executeInsert($metadata, $insert);
         return $model;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createSchemata(EntityMetadata $metadata)
+    {
+        $collection = $this->getQuery()->getModelCollection($metadata);
+        $schemata = $metadata->persistence->schemata ?: [];
+        return $this->schemaManager->createSchemata($collection, $schemata);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function syncSchemata(EntityMetadata $metadata)
+    {
+        $collection = $this->getQuery()->getModelCollection($metadata);
+        $schemata = $metadata->persistence->schemata ?: [];
+        return $this->schemaManager->syncSchemata($collection);
     }
 
     /**

--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -21,6 +21,9 @@ class SchemaManager
     public function createSchemata(Collection $collection, array $schemata)
     {
         foreach ($schemata as $schema) {
+            if (!isset($schema['keys']) || empty($schema['keys'])) {
+                throw new \InvalidArgumentException('Cannot create an index with no keys defined.');
+            }
             $schema['options']['background'] = true;
             $collection->ensureIndex($schema['keys'], $schema['options']);
         }

--- a/src/SchemaManager.php
+++ b/src/SchemaManager.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace As3\Modlr\Persister\MongoDb;
+
+use Doctrine\MongoDB\Collection;
+
+/**
+ * Handles requests to create or sync schema
+ *
+ * @author  Josh Worden <solocommand@gmail.com>
+ * @todo    This should be updated to read indices from the metadata factory
+ */
+class SchemaManager
+{
+    /**
+     * Applies schemata
+     *
+     * @param   Collection  $collection     The MongoDB Collection
+     * @param   array       $index          Associative array containing index data
+     */
+    public function createSchemata(Collection $collection, array $schemata)
+    {
+        foreach ($schemata as $schema) {
+            $schema['options']['background'] = true;
+            $collection->ensureIndex($schema['keys'], $schema['options']);
+        }
+    }
+
+    /**
+     * Syncs schemata state
+     * @todo    Implement
+     *
+     * @param   Collection  $collection     The MongoDB Collection
+     * @param   array       $index              Associative array containing index data
+     */
+    public function syncSchemata(Collection $collection, array $schemata)
+    {
+        return false;
+        // Remove all indices that match the expected format (modlr_md5hash) and are NOT present in $schemata
+
+        // Loop over $schemata and force update or remove/add index. Ensure background:true
+    }
+}

--- a/src/StorageMetadata.php
+++ b/src/StorageMetadata.php
@@ -37,6 +37,13 @@ class StorageMetadata implements StorageLayerInterface
     public $idStrategy = 'object';
 
     /**
+     * Configured schemata for this entity
+     *
+     * @var array
+     */
+    public $schemata = [];
+
+    /**
      * {@inheritDoc}
      */
     public function getKey()

--- a/src/StorageMetadataFactory.php
+++ b/src/StorageMetadataFactory.php
@@ -150,7 +150,7 @@ final class StorageMetadataFactory implements StorageMetadataFactoryInterface
             if (empty($schema['keys'])) {
                 throw MetadataException::invalidMetadata($metadata->type, 'At least one key must be specified to define an index.');
             }
-            $persistence->schemata[$k]['name'] = sprintf('modlr_%s', md5(json_encode($schema)));
+            $persistence->schemata[$k]['options']['name'] = sprintf('modlr_%s', md5(json_encode($schema)));
         }
     }
 }

--- a/src/StorageMetadataFactory.php
+++ b/src/StorageMetadataFactory.php
@@ -147,7 +147,7 @@ final class StorageMetadataFactory implements StorageMetadataFactoryInterface
     {
         $persistence = $metadata->persistence;
         foreach ($persistence->schemata as $k => $schema) {
-            if (empty($schema['keys'])) {
+            if (!isset($schema['keys']) || empty($schema['keys'])) {
                 throw MetadataException::invalidMetadata($metadata->type, 'At least one key must be specified to define an index.');
             }
             $persistence->schemata[$k]['options']['name'] = sprintf('modlr_%s', md5(json_encode($schema)));


### PR DESCRIPTION
Adds support at the MongoDB persister layer for creating schema from persistence metadata.
